### PR TITLE
removed conservative_impl_trait attribute

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(conservative_impl_trait)]
 #![cfg_attr(feature = "benches", feature(test))]
 
 #[cfg(feature = "benches")]


### PR DESCRIPTION
I removed #![feature(conservative_impl_trait)] attribute because this feature has been stable since 1.26.0 .
