### PR TITLE
Update gimli and addr2line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,11 +1,11 @@
 [[package]]
 name = "addr2line"
-version = "0.7.0"
-source = "git+https://github.com/gimli-rs/addr2line.git?rev=b1ac5ae4325bdcd16501d71d0e69207ce9ecb004#b1ac5ae4325bdcd16501d71d0e69207ce9ecb004"
+version = "0.8.0"
+source = "git+https://github.com/gimli-rs/addr2line.git?rev=1535f8f5e11b0b78512ce3c42316a1a0936eed3d#1535f8f5e11b0b78512ce3c42316a1a0936eed3d"
 dependencies = [
  "cpp_demangle 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "gimli 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gimli 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "intervaltree 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -270,7 +270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gimli"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -465,12 +465,12 @@ dependencies = [
 name = "nwind"
 version = "0.1.0"
 dependencies = [
- "addr2line 0.7.0 (git+https://github.com/gimli-rs/addr2line.git?rev=b1ac5ae4325bdcd16501d71d0e69207ce9ecb004)",
+ "addr2line 0.8.0 (git+https://github.com/gimli-rs/addr2line.git?rev=1535f8f5e11b0b78512ce3c42316a1a0936eed3d)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpp_demangle 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gimli 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gimli 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1070,7 +1070,7 @@ dependencies = [
 ]
 
 [metadata]
-"checksum addr2line 0.7.0 (git+https://github.com/gimli-rs/addr2line.git?rev=b1ac5ae4325bdcd16501d71d0e69207ce9ecb004)" = "<none>"
+"checksum addr2line 0.8.0 (git+https://github.com/gimli-rs/addr2line.git?rev=1535f8f5e11b0b78512ce3c42316a1a0936eed3d)" = "<none>"
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayvec 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d18513977c2d8261c448511c5c53dc66b26dfccbc3d4446672dea1e71a7d8a26"
@@ -1100,7 +1100,7 @@ dependencies = [
 "checksum fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eb7217124812dc5672b7476d0c2d20cfe9f7c0f1ba0904b674a9762a0212f72e"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum gimli 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7f6ee5390883802431e4abe323390f52f10ff16e8f8d2d6ce598251f900ede"
+"checksum gimli 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb3243218ca3773e9aa00d27602f35bd1daca3be1b7112ea5fc23b2899f1a4f3"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum goblin 0.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "c65cd533b33e3d04c6e393225fa8919ddfcf5862ca8919c7f9a167c312ef41c2"
 "checksum handlebars 0.32.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d89ec99d1594f285d4590fc32bac5f75cdab383f1123d504d27862c644a807dd"

--- a/nwind/Cargo.toml
+++ b/nwind/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Jan Bujak <jan.bujak@nokia.com>"]
 
 [dependencies]
 byteorder = "1"
-gimli = "0.16"
+gimli = { version = "0.17", default-features = false, features = ["std", "read"] }
 goblin = "0.0.19"
 scroll = "0.9"
 memmap = "0.7"
@@ -15,7 +15,7 @@ speedy-derive = "0.3"
 lru = "0.1"
 string-interner = "0.7"
 cpp_demangle = "0.2"
-addr2line = { version = "0.7", optional = true, default-features = false, features = ["cpp_demangle"], git = "https://github.com/gimli-rs/addr2line.git", rev = "b1ac5ae4325bdcd16501d71d0e69207ce9ecb004" }
+addr2line = { version = "0.8", optional = true, default-features = false, features = ["std", "cpp_demangle"], git = "https://github.com/gimli-rs/addr2line.git", rev = "1535f8f5e11b0b78512ce3c42316a1a0936eed3d" }
 proc-maps = { version = "0.1", path = "../proc-maps" }
 libc = "0.2"
 

--- a/nwind/src/address_space.rs
+++ b/nwind/src/address_space.rs
@@ -79,11 +79,15 @@ mod addr2line {
 
         pub fn from_sections(
             _: gimli::DebugAbbrev< T >,
+            _: gimli::DebugAddr< T >,
             _: gimli::DebugInfo< T >,
             _: gimli::DebugLine< T >,
+            _: gimli::DebugLineStr< T >,
             _: gimli::DebugRanges< T >,
             _: gimli::DebugRngLists< T >,
-            _: gimli::DebugStr< T >
+            _: gimli::DebugStr< T >,
+            _: gimli::DebugStrOffsets< T >,
+            _: T
         ) -> Result< Self, () > {
             Err(())
         }
@@ -914,7 +918,11 @@ fn reload< A: Architecture >(
                         BinaryData::get_section_or_empty( &binary_data ),
                         BinaryData::get_section_or_empty( &binary_data ),
                         BinaryData::get_section_or_empty( &binary_data ),
-                        BinaryData::get_section_or_empty( &binary_data )
+                        BinaryData::get_section_or_empty( &binary_data ),
+                        BinaryData::get_section_or_empty( &binary_data ),
+                        BinaryData::get_section_or_empty( &binary_data ),
+                        BinaryData::get_section_or_empty( &binary_data ),
+                        BinaryData::get_empty_section( &binary_data )
                     );
 
                     match ctx {

--- a/nwind/src/arch/amd64.rs
+++ b/nwind/src/arch/amd64.rs
@@ -101,18 +101,18 @@ fn guess_ebp< M: MemoryReader< Arch > >( nth_frame: usize, memory: &M, ctx_cache
     let unwind_info = binary.lookup_unwind_row( ctx_cache, rip )?;
 
     let cfa_offset = match unwind_info.cfa() {
-        CfaRule::RegisterAndOffset { register: cfa_register, offset: cfa_offset } if cfa_register as u16 == dwarf::RBP => cfa_offset,
+        CfaRule::RegisterAndOffset { register: cfa_register, offset: cfa_offset } if cfa_register == gimli::X86_64::RBP => cfa_offset,
         _ => return None
     };
 
     // What this rule means is that:
     //   previous.RBP == *(current.RBP + rbp_offset)
-    let rbp_offset = match unwind_info.register( dwarf::RBP as _ ) {
+    let rbp_offset = match unwind_info.register( gimli::X86_64::RBP ) {
         RegisterRule::Offset( offset ) => offset + cfa_offset,
         _ => return None
     };
 
-    let ra_offset = match unwind_info.register( dwarf::RETURN_ADDRESS as _ ) {
+    let ra_offset = match unwind_info.register( gimli::X86_64::RA ) {
         RegisterRule::Offset( offset ) => offset + cfa_offset,
         _ => return None
     };

--- a/nwind/src/binary.rs
+++ b/nwind/src/binary.rs
@@ -408,6 +408,11 @@ impl BinaryData {
     }
 
     #[inline]
+    pub fn get_empty_section( data: &Arc< BinaryData > ) -> BinaryDataReader {
+        Self::get_range_reader( data, 0..0 )
+    }
+
+    #[inline]
     pub fn get_section_or_empty< S >( data: &Arc< BinaryData > ) -> S
         where S: From< gimli::EndianReader< gimli::RunTimeEndian, BinaryDataSlice > > +
                  gimli::Section< gimli::EndianReader< gimli::RunTimeEndian, BinaryDataSlice > >
@@ -417,7 +422,11 @@ impl BinaryData {
             Some( range ) => range.clone(),
             None => 0..0
         };
+        Self::get_range_reader( data, range ).into()
+    }
 
+    #[inline]
+    fn get_range_reader( data: &Arc< BinaryData >, range: Range< usize > ) -> BinaryDataReader {
         let endianness = match data.endianness() {
             Endianness::LittleEndian => gimli::RunTimeEndian::Little,
             Endianness::BigEndian => gimli::RunTimeEndian::Big


### PR DESCRIPTION
This updates to gimli 0.17.0. We still need a new addr2line release before this can be merged though.

The gimli register definitions could be used more extensively, but it's still missing some of the definitions you have (eg MIPS).