### PR TITLE
Option for not using SIGSTOP/SIGCONT because not all apps take it well

### DIFF
--- a/nwind/src/unwind_context.rs
+++ b/nwind/src/unwind_context.rs
@@ -96,6 +96,12 @@ impl< 'a, A: Architecture > UnwindHandle< 'a, A > {
 
         self.ctx.nth_frame += 1;
 
+        // avoid infinite loops
+        if self.ctx.nth_frame > 100 {
+            warn!("infinite loop detected and avoided");
+            return false;
+        }
+
         self.ctx.address = self.ctx.regs.get( A::INSTRUCTION_POINTER_REG ).unwrap();
         debug!( "Unwinding #{} -> #{} at: 0x{:016X}", self.ctx.nth_frame - 1, self.ctx.nth_frame, self.ctx.address );
 

--- a/nwind/src/unwind_context.rs
+++ b/nwind/src/unwind_context.rs
@@ -98,7 +98,7 @@ impl< 'a, A: Architecture > UnwindHandle< 'a, A > {
 
         // avoid infinite loops
         if self.ctx.nth_frame > 1000 {
-            warn!("infinite loop detected and avoided");
+            warn!("possible infinite loop detected and avoided");
             return false;
         }
 

--- a/nwind/src/unwind_context.rs
+++ b/nwind/src/unwind_context.rs
@@ -97,7 +97,7 @@ impl< 'a, A: Architecture > UnwindHandle< 'a, A > {
         self.ctx.nth_frame += 1;
 
         // avoid infinite loops
-        if self.ctx.nth_frame > 100 {
+        if self.ctx.nth_frame > 1000 {
             warn!("infinite loop detected and avoided");
             return false;
         }

--- a/src/args.rs
+++ b/src/args.rs
@@ -198,8 +198,8 @@ pub struct RecordArgs {
     pub profiler_args: GenericProfilerArgs,
 
     #[structopt(long)]
-    /// Do not stop processes before gathering its info
-    pub dont_stop_processes: bool,
+    /// Do not send SIGSTOP before hooking into the process
+    pub do_not_send_sigstop: bool,
 }
 
 #[derive(StructOpt, Debug)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -199,7 +199,7 @@ pub struct RecordArgs {
 
     #[structopt(long)]
     /// Do not stop processes before gathering its info
-    pub dont_stop_processes: bool
+    pub dont_stop_processes: bool,
 }
 
 #[derive(StructOpt, Debug)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -195,7 +195,11 @@ pub struct RecordArgs {
     pub discard_all: bool,
 
     #[structopt(flatten)]
-    pub profiler_args: GenericProfilerArgs
+    pub profiler_args: GenericProfilerArgs,
+
+    #[structopt(long)]
+    /// Do not stop processes before gathering its info
+    pub dont_stop_processes: bool
 }
 
 #[derive(StructOpt, Debug)]

--- a/src/cmd_record.rs
+++ b/src/cmd_record.rs
@@ -59,7 +59,7 @@ pub fn main( args: args::RecordArgs ) -> Result< (), Box< dyn Error > > {
     });
 
     info!( "Opening perf events for process with PID {}...", controller.pid() );
-    let mut perf = match PerfGroup::open( controller.pid(), args.frequency, args.stack_size, args.event_source ) {
+    let mut perf = match PerfGroup::open( controller.pid(), args.frequency, args.stack_size, args.event_source, !args.dont_stop_processes ) {
         Ok( perf ) => perf,
         Err( error ) => {
             error!( "Failed to start profiling: {}", error );

--- a/src/cmd_record.rs
+++ b/src/cmd_record.rs
@@ -59,7 +59,7 @@ pub fn main( args: args::RecordArgs ) -> Result< (), Box< dyn Error > > {
     });
 
     info!( "Opening perf events for process with PID {}...", controller.pid() );
-    let mut perf = match PerfGroup::open( controller.pid(), args.frequency, args.stack_size, args.event_source, !args.dont_stop_processes ) {
+    let mut perf = match PerfGroup::open( controller.pid(), args.frequency, args.stack_size, args.event_source, !args.do_not_send_sigstop ) {
         Ok( perf ) => perf,
         Err( error ) => {
             error!( "Failed to start profiling: {}", error );

--- a/src/perf_group.rs
+++ b/src/perf_group.rs
@@ -174,7 +174,7 @@ impl PerfGroup {
             event_source,
             initial_events: Vec::new(),
             stopped_processes: Vec::new(),
-            stop_processes: stop_processes
+            stop_processes
         };
 
         group

--- a/src/perf_group.rs
+++ b/src/perf_group.rs
@@ -103,7 +103,7 @@ pub struct PerfGroup {
     event_source: EventSource,
     initial_events: Vec< Event< 'static > >,
     stopped_processes: Vec< StoppedProcess >,
-    stop_processes: bool
+    stop_processes: bool,
 }
 
 fn poll_events< 'a, I >( poll_fds: &mut Vec< libc::pollfd >, iter: I ) where I: IntoIterator< Item = &'a Member >, <I as IntoIterator>::IntoIter: Clone {


### PR DESCRIPTION
This STOP/CONT pattern is used to avoid data-race between reading /proc and handling things like mmap events from the kernel, isn't it? Anyway, we are profiling some apps that don't take it very well since STOP causes syscalls to return abnormally. It should be fixed but you know, it is not always that easy. Therefore I'm proposing a switch to disable this behavior.