### PR TITLE
Add a C API `nwind_backtrace` around the local unwind API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "nwind-capi"
+version = "0.1.0"
+dependencies = [
+ "nwind",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,7 @@ dependencies = [
 name = "nwind-capi"
 version = "0.1.0"
 dependencies = [
+ "env_logger 0.8.4",
  "nwind",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ addr2line = ["nwind/addr2line"]
 debug-logs = ["nwind/debug-logs"]
 
 [workspace]
-members = [".", "cli", "nwind", "proc-maps", "perf_event_open", "thread-local-reentrant"]
+members = [".", "cli", "nwind", "nwind-capi", "proc-maps", "perf_event_open", "thread-local-reentrant"]
 
 [[bench]]
 name = "unwinding"

--- a/nwind-capi/Cargo.toml
+++ b/nwind-capi/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "nwind-capi"
+version = "0.1.0"
+authors = ["Milian Wolff <mail@milianw.de>"]
+edition = "2018"
+readme = "README.md"
+repository = "https://github.com/koute/not-perf"
+homepage = "https://github.com/koute/not-perf"
+description = """
+Fast caching unw_backtrace implementation based on a shadow stack
+"""
+
+[dependencies]
+nwind = { version = "0.1", path = "../nwind", features = ["local-unwinding"] }
+
+[lib]
+name = "nwind_capi"
+crate-type = ["staticlib", "cdylib"]
+

--- a/nwind-capi/Cargo.toml
+++ b/nwind-capi/Cargo.toml
@@ -11,9 +11,12 @@ Fast caching unw_backtrace implementation based on a shadow stack
 """
 
 [dependencies]
-nwind = { version = "0.1", path = "../nwind", features = ["local-unwinding"] }
+nwind = { version = "0.1", path = "../nwind", default-features = false, features = ["local-unwinding"] }
+env_logger = { version = "0.8", optional = true }
 
 [lib]
 name = "nwind_capi"
 crate-type = ["staticlib", "cdylib"]
 
+[features]
+env_logger = ["dep:env_logger", "nwind/debug-logs"]

--- a/nwind-capi/README.md
+++ b/nwind-capi/README.md
@@ -1,0 +1,28 @@
+# nwind C API - shadow stack
+
+A simple C API wrapper around the unwind crate written in rust.
+
+Example usage:
+
+```
+int use_shadow_stack = 1;
+
+/* the address space can be reused across threads */
+nwind_address_space* address_space = nwind_create_address_space(use_shadow_stack);
+
+/* you need to reload the address space whenever it changes, e.g. after `dlopen` or `mmap` */
+nwind_reload_address_space(address_space);
+
+/* the unwind context should be thread local */
+nwind_unwind_context* unwind_context = nwind_create_unwind_context();
+
+/* unwind into an existing buffer, note that this can be done multiple times, reusing a
+   central address space and a thread specific unwind context */
+int buffer_size = 64;
+void **buffer[buffer_size] = {0};
+int stack_size = nwind_backtrace(address_space, unwind_context, buffer, buffer_size);
+
+/* cleanup resources */
+nwind_free_unwind_context(unwind_context);
+nwind_free_address_space(unwind_context);
+```

--- a/nwind-capi/include/nwind_capi.h
+++ b/nwind-capi/include/nwind_capi.h
@@ -1,0 +1,103 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef NWIND_CAPI_H_
+#define NWIND_CAPI_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque handle for a local address space */
+typedef struct nwind_local_address_space_ nwind_local_address_space;
+
+/* Opaque handle for a local unwind context */
+typedef struct nwind_local_unwind_context_ nwind_local_unwind_context;
+
+/**
+ * Create a local address space to use for unwinding.
+ *
+ * This type can be reused across threads, as long as the address space stays
+ * the same. When dlopen is called or the address space is otherwise mutated,
+ * @c nwind_reload_local_address_space needs to be called before using the
+ * address space for unwinding again.
+ *
+ * @sa nwind_free_local_address_space, nwind_reload_local_address_space
+ * @sa nwind_create_local_unwind_context, nwind_local_backtrace
+ * @sa nwind_local_address_space_is_shadow_stack_enabled
+ * @sa nwind_local_address_space_use_shadow_stack
+ */
+nwind_local_address_space *nwind_create_local_address_space();
+
+/**
+ * Free the memory associated with the address space.
+ *
+ * @sa nwind_create_local_address_space
+ */
+void nwind_free_local_address_space(nwind_local_address_space *address_space);
+
+/**
+ * @return 1 when the shadow stack should be used for unwinding and 0 otherwise
+ * @sa nwind_create_local_address_space
+ */
+int nwind_local_address_space_is_shadow_stack_enabled(
+    nwind_local_address_space *address_space);
+
+/**
+ * @param use_shadow_stack set to 1 when the shadow stack should be used for
+ * unwinding and 0 otherwise
+ * @sa nwind_create_local_address_space
+ */
+void nwind_local_address_space_use_shadow_stack(
+    nwind_local_address_space *address_space, int use_shadow_stack);
+
+/**
+ * Reload the local address space to re-read the mapping.
+ *
+ * When dlopen is called or the address space is otherwise mutated, the address
+ * space needs to be reloaded.
+ *
+ * @sa nwind_create_local_address_space
+ */
+nwind_local_address_space *
+nwind_reload_local_address_space(nwind_local_address_space *address_space);
+
+/**
+ * Create a unwind context to use for unwinding.
+ *
+ * This type can be cached within a single thread and reused across repeated
+ * calls to @c nwind_local_backtrace.
+ *
+ * @sa nwind_free_local_unwind_context, nwind_create_local_address_space
+ * @sa nwind_local_backtrace
+ */
+nwind_local_unwind_context *nwind_create_local_unwind_context(void);
+
+/**
+ * Free the memory associated with the unwind context.
+ *
+ * @sa nwind_create_local_unwind_context
+ */
+void nwind_free_local_unwind_context(
+    nwind_local_unwind_context *unwind_local_context);
+
+/**
+ * Unwind the stack and return up to @p size frames in the backtrace @p buffer.
+ *
+ * @param address_space the local address space to use
+ * @param unwind_local_context the unwind context to use
+ * @param buffer the output buffer in which the backtrace will be stored
+ * @param size the maximum number of frames that will be stored into the buffer
+ * @return the number of frames written to the output @p buffer.
+ *
+ * @sa nwind_create_local_address_space, nwind_create_local_unwind_context
+ * @sa nwind_reload_local_address_space
+ */
+size_t nwind_local_backtrace(nwind_local_address_space *address_space,
+                             nwind_local_unwind_context *unwind_local_context,
+                             void **buffer, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NWIND_CAPI_H_

--- a/nwind-capi/src/lib.rs
+++ b/nwind-capi/src/lib.rs
@@ -1,9 +1,14 @@
+#[cfg(feature = "env_logger")]
+extern crate env_logger;
+
 use nwind::{LocalAddressSpace, LocalAddressSpaceOptions, LocalUnwindContext, UnwindControl};
 
 use core::ffi::{c_int, c_void};
 
 #[no_mangle]
 pub unsafe extern "C" fn nwind_create_local_address_space() -> *mut LocalAddressSpace {
+    #[cfg(feature = "env_logger")]
+    let _ = env_logger::try_init();
     let opts = LocalAddressSpaceOptions::new().should_load_symbols(false);
     let address_space = LocalAddressSpace::new_with_opts(opts).unwrap();
 

--- a/nwind-capi/src/lib.rs
+++ b/nwind-capi/src/lib.rs
@@ -1,0 +1,85 @@
+use nwind::{LocalAddressSpace, LocalAddressSpaceOptions, LocalUnwindContext, UnwindControl};
+
+use core::ffi::{c_int, c_void};
+
+#[no_mangle]
+pub unsafe extern "C" fn nwind_create_local_address_space() -> *mut LocalAddressSpace {
+    let opts = LocalAddressSpaceOptions::new().should_load_symbols(false);
+    let address_space = LocalAddressSpace::new_with_opts(opts).unwrap();
+
+    Box::into_raw(Box::new(address_space))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn nwind_free_local_address_space(address_space: *mut LocalAddressSpace) {
+    drop(Box::from_raw(address_space))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn nwind_local_address_space_is_shadow_stack_enabled(
+    address_space: *mut LocalAddressSpace,
+) -> c_int {
+    (*address_space).is_shadow_stack_enabled() as c_int
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn nwind_local_address_space_use_shadow_stack(
+    address_space: *mut LocalAddressSpace,
+    use_shadow_stack: c_int,
+) {
+    (*address_space).use_shadow_stack(use_shadow_stack == 1);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn nwind_reload_local_address_space(address_space: *mut LocalAddressSpace) {
+    (*address_space).reload().unwrap();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn nwind_create_local_unwind_context() -> *mut LocalUnwindContext {
+    Box::into_raw(Box::new(LocalUnwindContext::new()))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn nwind_free_local_unwind_context(
+    local_unwind_context: *mut LocalUnwindContext,
+) {
+    drop(Box::from_raw(local_unwind_context))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn nwind_local_backtrace(
+    address_space: *mut LocalAddressSpace,
+    unwind_context: *mut LocalUnwindContext,
+    buffer: *mut *mut c_void,
+    size: c_int,
+) -> c_int {
+    if size <= 0 {
+        return 0;
+    }
+
+    let size = size as usize;
+
+    let buffer = core::slice::from_raw_parts_mut(buffer, size);
+
+    let mut first = true;
+    let mut ret: usize = 0;
+    (*address_space).unwind(unwind_context.as_mut().unwrap(), |address| {
+        if first {
+            // skip the first frame as that would point at nwind_backtrace
+            first = false;
+            return UnwindControl::Continue;
+        }
+
+        buffer[ret] = address as *mut c_void;
+        ret += 1;
+
+        if ret == size {
+            UnwindControl::Stop
+        } else {
+            UnwindControl::Continue
+        }
+    });
+
+    ret as c_int
+}

--- a/nwind/src/frame_descriptions.rs
+++ b/nwind/src/frame_descriptions.rs
@@ -460,7 +460,12 @@ impl< E: Endianity > FrameDescriptions< E > {
             if debug_logs_enabled!() {
                 match eh_frame_hdr.table().unwrap().lookup( address, bases ) {
                     Ok( gimli::Pointer::Direct( pointer ) ) => {
-                        debug!( "FDE pointer for {:016X} from .eh_frame_hdr: {:016X} (relative: 0x{:X})", address, pointer, pointer - bases.eh_frame_hdr.section.unwrap() );
+                        let base = bases.eh_frame_hdr.section.unwrap();
+                        if pointer < base {
+                            warn!( "FDE pointer for {:016X} from .eh_frame_hdr: {:016X} (relative: -0x{:X}", address, pointer, base - pointer );
+                        } else {
+                            debug!( "FDE pointer for {:016X} from .eh_frame_hdr: {:016X} (relative: 0x{:X})", address, pointer, pointer - base);
+                        }
                     },
                     _ => {}
                 }


### PR DESCRIPTION
This allows other projects not written in Rust to consume this unwinding library. The API is pretty basic and only offers the fundamental building blocks required for an external consumer to drive the unwinding. There is no fancy lazy global static address space, nor any thread local unwind context - configuring that is left to the consumer of this API.

Fixes: https://github.com/koute/bytehound/issues/8